### PR TITLE
DBus: Set a fallback title when no body is provided

### DIFF
--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -68,6 +68,12 @@ public class Notifications.Server : Object {
             app_icon = "dialog-information";
         }
 
+        /*Only summary is required by GLib, so try to set a title when body is empty*/
+        if (body == "") {
+            body = summary;
+            summary = app_name;
+        }
+
         var notification = new Notifications.Notification (
             app_icon,
             summary,


### PR DESCRIPTION
GLib.Notification only requires that the notification title is set. However, our notification design is that we want a title and a body. So, if body is "", we make the body the `summary` and use `app_name` for the title text.

Not sure if the comment is too obvious :man_shrugging: 