### PR TITLE
DBus: get fallback icon from appinfo

### DIFF
--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -64,12 +64,13 @@ public class Notifications.Server : Object {
         int32 expire_timeout,
         BusName sender
     ) throws DBusError, IOError {
+        unowned Variant? variant = null;
+
         string icon = app_icon;
         if (icon == "") {
-            unowned Variant? variant = hints.lookup ("desktop-entry");
             AppInfo? app_info = null;
 
-            if (variant != null && variant.is_of_type (VariantType.STRING)) {
+            if ((variant = hints.lookup ("desktop-entry")) != null && variant.is_of_type (VariantType.STRING)) {
                 string desktop_id = variant.get_string ();
                 if (!desktop_id.has_suffix (".desktop")) {
                     desktop_id += ".desktop";

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -65,29 +65,20 @@ public class Notifications.Server : Object {
         BusName sender
     ) throws DBusError, IOError {
         unowned Variant? variant = null;
+        AppInfo? app_info = null;
 
-        string icon = app_icon;
-        if (icon == "") {
-            AppInfo? app_info = null;
-
-            if ((variant = hints.lookup ("desktop-entry")) != null && variant.is_of_type (VariantType.STRING)) {
-                string desktop_id = variant.get_string ();
-                if (!desktop_id.has_suffix (".desktop")) {
-                    desktop_id += ".desktop";
-                }
-
-                app_info = new DesktopAppInfo (desktop_id);
+        if ((variant = hints.lookup ("desktop-entry")) != null && variant.is_of_type (VariantType.STRING)) {
+            string desktop_id = variant.get_string ();
+            if (!desktop_id.has_suffix (".desktop")) {
+                desktop_id += ".desktop";
             }
 
-			if (app_info != null) {
-                icon = app_info.get_icon ().to_string ();
-            } else {
-                icon = "dialog-information";
-            }
+            app_info = new DesktopAppInfo (desktop_id);
         }
 
         var notification = new Notifications.Notification (
-            icon,
+            app_info,
+            app_icon,
             summary,
             body
         );

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -64,12 +64,29 @@ public class Notifications.Server : Object {
         int32 expire_timeout,
         BusName sender
     ) throws DBusError, IOError {
-        if (app_icon == "") {
-            app_icon = "dialog-information";
+        string icon = app_icon;
+        if (icon == "") {
+            unowned Variant? variant = hints.lookup ("desktop-entry");
+            AppInfo? app_info = null;
+
+            if (variant != null && variant.is_of_type (VariantType.STRING)) {
+                string desktop_id = variant.get_string ();
+                if (!desktop_id.has_suffix (".desktop")) {
+                    desktop_id += ".desktop";
+                }
+
+                app_info = new DesktopAppInfo (desktop_id);
+            }
+
+			if (app_info != null) {
+                icon = app_info.get_icon ().to_string ();
+            } else {
+                icon = "dialog-information";
+            }
         }
 
         var notification = new Notifications.Notification (
-            app_icon,
+            icon,
             summary,
             body
         );

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -22,12 +22,12 @@ public class Notifications.Notification : Gtk.Window {
     public string app_icon { get; construct; }
     public string body { get; construct; }
     public new string title { get; construct; }
-    public GLib.AppInfo app_info { get; construct; }
+    public GLib.AppInfo? app_info { get; construct; }
     public GLib.NotificationPriority priority { get; set; default = GLib.NotificationPriority.NORMAL; }
 
     private uint timeout_id;
 
-    public Notification (GLib.AppInfo app_info, string app_icon, string title, string body) {
+    public Notification (GLib.AppInfo? app_info, string app_icon, string title, string body) {
         Object (
             app_info: app_info,
             title: title,

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -22,12 +22,14 @@ public class Notifications.Notification : Gtk.Window {
     public string app_icon { get; construct; }
     public string body { get; construct; }
     public new string title { get; construct; }
+    public GLib.AppInfo app_info { get; construct; }
     public GLib.NotificationPriority priority { get; set; default = GLib.NotificationPriority.NORMAL; }
 
     private uint timeout_id;
 
-    public Notification (string app_icon, string title, string body) {
+    public Notification (GLib.AppInfo app_info, string app_icon, string title, string body) {
         Object (
+            app_info: app_info,
             title: title,
             body: body,
             app_icon: app_icon
@@ -35,6 +37,14 @@ public class Notifications.Notification : Gtk.Window {
     }
 
     construct {
+        if (app_icon == "") {
+			if (app_info != null) {
+                app_icon = app_info.get_icon ().to_string ();
+            } else {
+                app_icon = "dialog-information";
+            }
+        }
+
         var image = new Gtk.Image.from_icon_name (app_icon, Gtk.IconSize.DIALOG);
         image.valign = Gtk.Align.START;
         image.pixel_size = 48;

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -23,7 +23,7 @@ public class Notifications.Notification : Gtk.Window {
     public string body { get; construct; }
     public new string title { get; construct; }
     public uint32 id { get; construct; }
-    public GLib.AppInfo? app_info { get; construct; }
+    public unowned GLib.AppInfo? app_info { get; construct; }
     public GLib.NotificationPriority priority { get; set; default = GLib.NotificationPriority.NORMAL; }
 
     private uint timeout_id;


### PR DESCRIPTION
Fixes #7 

Since GLib.Notification only requires a title, we try to get the app icon from AppInfo when it's not supplied.

We need to pass appinfo into the notification because of actions, so might as well do it in this PR as well