### PR TITLE
Set notification priority

### DIFF
--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -64,14 +64,22 @@ public class Notifications.Server : Object {
         int32 expire_timeout,
         BusName sender
     ) throws DBusError, IOError {
+        unowned Variant? variant = null;
+
         if (app_icon == "") {
             app_icon = "dialog-information";
+        }
+
+        var priority = GLib.NotificationPriority.NORMAL;
+        if ((variant = hints.lookup ("urgency")) != null) {
+            priority = (GLib.NotificationPriority) variant.get_byte ();
         }
 
         var notification = new Notifications.Notification (
             app_icon,
             summary,
-            body
+            body,
+            priority
         );
         notification.show_all ();
 

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -72,7 +72,7 @@ public class Notifications.Server : Object {
         }
 
         var priority = GLib.NotificationPriority.NORMAL;
-        if ((variant = hints.lookup ("urgency")) != null) {
+        if ((variant = hints.lookup ("urgency")) != null && variant.is_of_type (VariantType.BYTE)) {
             priority = (GLib.NotificationPriority) variant.get_byte ();
         }
 

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -23,8 +23,8 @@ public class Notifications.Notification : Gtk.Window {
     public string body { get; construct; }
     public new string title { get; construct; }
     public uint32 id { get; construct; }
-    public GLib.NotificationPriority priority { get; construct; }    
-    
+    public GLib.NotificationPriority priority { get; construct; }
+
     private uint timeout_id;
 
     public Notification (string app_icon, string title, string body, GLib.NotificationPriority priority, uint32 id) {

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -22,15 +22,16 @@ public class Notifications.Notification : Gtk.Window {
     public string app_icon { get; construct; }
     public string body { get; construct; }
     public new string title { get; construct; }
-    public GLib.NotificationPriority priority { get; set; default = GLib.NotificationPriority.NORMAL; }
+    public GLib.NotificationPriority priority { get; construct; }
 
     private uint timeout_id;
 
-    public Notification (string app_icon, string title, string body) {
+    public Notification (string app_icon, string title, string body, GLib.NotificationPriority priority) {
         Object (
             title: title,
             body: body,
-            app_icon: app_icon
+            app_icon: app_icon,
+            priority: priority
         );
     }
 
@@ -82,21 +83,19 @@ public class Notifications.Notification : Gtk.Window {
         type_hint = Gdk.WindowTypeHint.NOTIFICATION;
         add (spacer);
 
-        timeout_id = GLib.Timeout.add (2500, () => {
-            timeout_id = 0;
-            destroy ();
-            return false;
-        });
-
-        notify["priority"].connect (() => {
-            if (priority == GLib.NotificationPriority.URGENT) {
+        switch (priority) {
+            case GLib.NotificationPriority.HIGH:
+            case GLib.NotificationPriority.URGENT:
                 get_style_context ().add_class ("urgent");
-                if (timeout_id != 0) {
-                    Source.remove (timeout_id);
+                break;
+            default:
+                timeout_id = GLib.Timeout.add (4000, () => {
                     timeout_id = 0;
-                }
-            }
-        });
+                    destroy ();
+                    return false;
+                });
+                break;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #5 

I set urgent for both high and critical because it seems like `notify-send` (and I'm wondering about `libnotify`) only has "low", "normal", or "critical" and what we get from GLib.NotificationPriority for `notify-send`'s "critical" is GLib's "high"