### PR TITLE
DBus: Create a method to send sounds

### DIFF
--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -83,12 +83,12 @@ public class Notifications.Server : Object {
         );
         notification.show_all ();
 
-        handle_sounds (hints);
+        send_sound (hints);
 
         return 0;
     }
 
-    private void handle_sounds (HashTable<string,Variant> hints) {
+    private void send_sound (HashTable<string,Variant> hints) {
         Variant? variant = null;
 
         variant = hints.lookup ("category");

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -93,9 +93,7 @@ public class Notifications.Server : Object {
     }
 
     private void send_sound (HashTable<string,Variant> hints) {
-        Variant? variant = null;
-
-        variant = hints.lookup ("category");
+        Variant? variant = hints.lookup ("category");
         unowned string? sound_name = "dialog-information";
 
         if (variant != null) {

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -36,6 +36,14 @@ public class Notifications.Server : Object {
             critical (e.message);
             bus_proxy = null;
         }
+
+        ca_context = CanberraGtk.context_get ();
+        ca_context.change_props (
+            Canberra.PROP_APPLICATION_NAME, "Notifications",
+            Canberra.PROP_APPLICATION_ID, "io.elementary.notifications",
+            null
+        );
+        ca_context.open ();
     }
 
     public string [] get_capabilities () throws DBusError, IOError {
@@ -75,21 +83,83 @@ public class Notifications.Server : Object {
         );
         notification.show_all ();
 
-        Canberra.Proplist props;
-        Canberra.Proplist.create (out props);
-
-        props.sets (Canberra.PROP_CANBERRA_CACHE_CONTROL, "volatile");
-        props.sets (Canberra.PROP_EVENT_ID, "dialog-information");
-
-        ca_context = CanberraGtk.context_get ();
-        ca_context.change_props (
-            Canberra.PROP_APPLICATION_NAME, "Notifications",
-            Canberra.PROP_APPLICATION_ID, "io.elementary.notifications",
-            null
-        );
-        ca_context.open ();
-        ca_context.play_full (0, props);
+        handle_sounds (hints);
 
         return 0;
+    }
+
+    private void handle_sounds (HashTable<string,Variant> hints) {
+        Variant? variant = null;
+
+        variant = hints.lookup ("category");
+        unowned string? sound_name = "dialog-information";
+
+        if (variant != null) {
+            sound_name = category_to_sound_name (variant.get_string ());
+        }
+
+        if (sound_name != null) {
+            Canberra.Proplist props;
+            Canberra.Proplist.create (out props);
+
+            props.sets (Canberra.PROP_CANBERRA_CACHE_CONTROL, "volatile");
+            props.sets (Canberra.PROP_EVENT_ID, sound_name);
+
+            ca_context.play_full (0, props);
+        }
+    }
+
+    static unowned string? category_to_sound_name (string category) {
+        unowned string? sound = null;
+        switch (category) {
+            case "device.added":
+                sound = "device-added";
+                break;
+            case "device.removed":
+                sound = "device-removed";
+                break;
+            case "im":
+                sound = "message";
+                break;
+            case "im.received":
+                sound = "message-new-instant";
+                break;
+            case "network.connected":
+                sound = "network-connectivity-established";
+                break;
+            case "network.disconnected":
+                sound = "network-connectivity-lost";
+                break;
+            case "presence.online":
+                sound = "service-login";
+                break;
+            case "presence.offline":
+                sound = "service-logout";
+                break;
+            // no sound at all
+            case "x-gnome.music":
+                sound = null;
+                break;
+            // generic errors
+            case "device.error":
+            case "email.bounced":
+            case "im.error":
+            case "network.error":
+            case "transfer.error":
+                sound = "dialog-error";
+                break;
+            // use generic default
+            case "network":
+            case "email":
+            case "email.arrived":
+            case "presence":
+            case "transfer":
+            case "transfer.complete":
+            default:
+                sound = "dialog-information";
+                break;
+        }
+
+        return sound;
     }
 }


### PR DESCRIPTION
Fixes #12 

* Only create canberra context once and use the same context for every notification
* Move sound sending to a method which makes it easy to disable when we support notification settings in the future
* Look for the notification category and try to auto select an appropriate sound based on that info