### PR TITLE
Support markup in the body

### DIFF
--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -61,6 +61,7 @@ public class Notifications.Notification : Gtk.Window {
         var body_label = new Gtk.Label (body);
         body_label.ellipsize = Pango.EllipsizeMode.END;
         body_label.lines = 2;
+        body_label.use_markup = true;
         body_label.valign = Gtk.Align.START;
         body_label.wrap = true;
         body_label.xalign = 0;


### PR DESCRIPTION
GNOME Power Manager for example sends `<b>` tags in the body text

![Screenshot from 2019-06-12 16 07 43@2x](https://user-images.githubusercontent.com/7277719/59392364-3cd23f80-8d2c-11e9-96bb-09e4f504d9e1.png)
