### PR TITLE
Reset timeout_id

### DIFF
--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -120,6 +120,7 @@ public class Notifications.Bubble : Gtk.Window {
         enter_notify_event.connect (() => {
             if (timeout_id != 0) {
                 Source.remove (timeout_id);
+                timeout_id = 0;
             }
         });
 


### PR DESCRIPTION
I approved #19 but I didn't check terminal output. We also have to reset the timeout ID to 0 when doing `Source.remove`.