### PR TITLE
Revert "Bubble: escape body text"

### DIFF
--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -58,7 +58,7 @@ public class Notifications.Bubble : Gtk.Window {
         title_label.xalign = 0;
         title_label.get_style_context ().add_class ("title");
 
-        var body_label = new Gtk.Label (Markup.escape_text (body));
+        var body_label = new Gtk.Label (body);
         body_label.ellipsize = Pango.EllipsizeMode.END;
         body_label.lines = 2;
         body_label.use_markup = true;


### PR DESCRIPTION
Reverts elementary/notifications#29

reopens #26 

This breaks markup text like the low power notification