### PR TITLE
Bubble: Max 2 line body and ellipsize

### DIFF
--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -104,6 +104,17 @@ public class Notifications.Bubble : AbstractBubble {
         body_label.wrap = true;
         body_label.xalign = 0;
 
+        if ("\n" in body) {
+            string[] lines = body.split ("\n");
+            string stripped_body = lines[0] + "\n";
+            for (int i = 1; i < lines.length; i++) {
+                stripped_body += lines[i].strip () + "";
+            }
+
+            body_label.label = stripped_body.strip ();
+            body_label.lines = 1;
+        }
+
         content_area.attach (image_overlay, 0, 0, 1, 2);
         content_area.attach (title_label, 1, 0);
         content_area.attach (body_label, 1, 1);


### PR DESCRIPTION
Fixes #31 

![Screenshot from 2020-03-06 10 46 21@2x](https://user-images.githubusercontent.com/7277719/76112881-f1d21980-5f97-11ea-80db-3cb0903f514d.png)

Make sure that the body is a maximum of 2 lines and we independently ellipsize each line