### PR TITLE
Create notification object

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ executable(
     'src/Bubble.vala',
     'src/Confirmation.vala',
     'src/DBus.vala',
+    'src/Notification.vala',
     'src/Widgets/MaskedImage.vala',
     css_gresource,
     dependencies: [

--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2019 elementary, Inc. (https://elementary.io)
+* Copyright 2019-2020 elementary, Inc. (https://elementary.io)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public
@@ -25,11 +25,7 @@ public class Notifications.Bubble : AbstractBubble {
     public string[] actions { get; construct; }
     public uint32 id { get; construct; }
 
-    public Bubble (
-        Notifications.Notification notification,
-        string[] actions,
-        uint32 id
-    ) {
+    public Bubble (Notifications.Notification notification, string[] actions, uint32 id) {
         Object (
             notification: notification,
             actions: actions,

--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -23,25 +23,22 @@ public class Notifications.Bubble : AbstractBubble {
 
     public Notifications.Notification notification { get; construct; }
     public string[] actions { get; construct; }
-    public string app_icon { get; construct; }
     public uint32 id { get; construct; }
 
     public Bubble (
         Notifications.Notification notification,
-        string app_icon,
         string[] actions,
         uint32 id
     ) {
         Object (
             notification: notification,
             actions: actions,
-            app_icon: app_icon,
             id: id
         );
     }
 
     construct {
-        var contents = new Contents (notification.app_info, notification.summary, app_icon, notification.body, notification.image_path);
+        var contents = new Contents (notification);
 
         content_area.add (contents);
 
@@ -97,13 +94,7 @@ public class Notifications.Bubble : AbstractBubble {
     public void replace (Notifications.Notification new_notification) {
         start_timeout (4000);
 
-        var new_contents = new Contents (
-            new_notification.app_info,
-            new_notification.summary,
-            app_icon,
-            new_notification.body,
-            new_notification.image_path
-        );
+        var new_contents = new Contents (new_notification);
         new_contents.show_all ();
 
         content_area.add (new_contents);
@@ -111,41 +102,23 @@ public class Notifications.Bubble : AbstractBubble {
     }
 
     private class Contents : Gtk.Grid {
-        public GLib.DesktopAppInfo? app_info { get; construct; }
-        public string app_icon { get; construct; }
-        public string body { get; construct; }
-        public string? image_path { get; construct; }
-        public string summary { get; construct; }
+        public Notifications.Notification notification { get; construct; }
 
-        public Contents (GLib.DesktopAppInfo? app_info, string summary, string app_icon, string body, string? image_path) {
-            Object (
-                app_icon: app_icon,
-                app_info: app_info,
-                body: body,
-                image_path: image_path,
-                summary: summary
-            );
+        public Contents (Notifications.Notification notification) {
+            Object (notification: notification);
         }
 
         construct {
-            if (app_icon == "") {
-                if (app_info != null) {
-                    app_icon = app_info.get_icon ().to_string ();
-                } else {
-                    app_icon = "dialog-information";
-                }
-            }
-
             var app_image = new Gtk.Image ();
-            app_image.icon_name = app_icon;
+            app_image.icon_name = notification.app_icon;
 
             var image_overlay = new Gtk.Overlay ();
             image_overlay.valign = Gtk.Align.START;
 
-            if (image_path != null) {
+            if (notification.image_path != null) {
                 try {
                     var scale = get_style_context ().get_scale ();
-                    var pixbuf = new Gdk.Pixbuf.from_file_at_size (image_path, 48 * scale, 48 * scale);
+                    var pixbuf = new Gdk.Pixbuf.from_file_at_size (notification.image_path, 48 * scale, 48 * scale);
 
                     var masked_image = new Notifications.MaskedImage (pixbuf);
 
@@ -165,7 +138,7 @@ public class Notifications.Bubble : AbstractBubble {
                 image_overlay.add (app_image);
             }
 
-            var title_label = new Gtk.Label (summary) {
+            var title_label = new Gtk.Label (notification.summary) {
                 ellipsize = Pango.EllipsizeMode.END,
                 max_width_chars = 33,
                 valign = Gtk.Align.END,
@@ -174,7 +147,7 @@ public class Notifications.Bubble : AbstractBubble {
             };
             title_label.get_style_context ().add_class ("title");
 
-            var body_label = new Gtk.Label (body) {
+            var body_label = new Gtk.Label (notification.body) {
                 ellipsize = Pango.EllipsizeMode.END,
                 lines = 2,
                 max_width_chars = 33,
@@ -185,8 +158,8 @@ public class Notifications.Bubble : AbstractBubble {
                 xalign = 0
             };
 
-            if ("\n" in body) {
-                string[] lines = body.split ("\n");
+            if ("\n" in notification.body) {
+                string[] lines = notification.body.split ("\n");
                 string stripped_body = lines[0] + "\n";
                 for (int i = 1; i < lines.length; i++) {
                     stripped_body += lines[i].strip () + "";

--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -21,46 +21,31 @@
 public class Notifications.Bubble : AbstractBubble {
     public signal void action_invoked (string action_key);
 
-    public GLib.DesktopAppInfo? app_info { get; construct; }
-    public GLib.NotificationPriority priority { get; construct; }
+    public Notifications.Notification notification { get; construct; }
     public string[] actions { get; construct; }
     public string app_icon { get; construct; }
-    public string app_name { get; construct; }
-    public string body { get; construct; }
-    public string? image_path { get; construct; }
-    public string summary { get; construct; }
     public uint32 id { get; construct; }
 
     public Bubble (
-        GLib.DesktopAppInfo? app_info,
+        Notifications.Notification notification,
         string app_icon,
-        string app_name,
-        string summary,
-        string body,
         string[] actions,
-        GLib.NotificationPriority priority,
-        string? image_path,
         uint32 id
     ) {
         Object (
-            app_info: app_info,
-            app_name: app_name,
-            summary: summary,
-            body: body,
+            notification: notification,
             actions: actions,
             app_icon: app_icon,
-            priority: priority,
-            image_path: image_path,
             id: id
         );
     }
 
     construct {
-        var contents = new Contents (app_name, app_info, summary, app_icon, body, image_path);
+        var contents = new Contents (notification.app_info, notification.summary, app_icon, notification.body, notification.image_path);
 
         content_area.add (contents);
 
-        switch (priority) {
+        switch (notification.priority) {
             case GLib.NotificationPriority.HIGH:
             case GLib.NotificationPriority.URGENT:
                 content_area.get_style_context ().add_class ("urgent");
@@ -70,7 +55,7 @@ public class Notifications.Bubble : AbstractBubble {
                 break;
         }
 
-        if (app_info != null) {
+        if (notification.app_info != null) {
             bool default_action = false;
 
             for (int i = 0; i < actions.length; i += 2) {
@@ -85,7 +70,7 @@ public class Notifications.Bubble : AbstractBubble {
                     launch_action ("default");
                 } else {
                     try {
-                        app_info.launch (null, null);
+                        notification.app_info.launch (null, null);
                         dismiss ();
                     } catch (Error e) {
                         critical ("Unable to launch app: %s", e.message);
@@ -96,7 +81,7 @@ public class Notifications.Bubble : AbstractBubble {
         }
 
         leave_notify_event.connect (() => {
-            if (priority == GLib.NotificationPriority.HIGH || priority == GLib.NotificationPriority.URGENT) {
+            if (notification.priority == GLib.NotificationPriority.HIGH || notification.priority == GLib.NotificationPriority.URGENT) {
                 return Gdk.EVENT_PROPAGATE;
             }
             start_timeout (4000);
@@ -104,15 +89,21 @@ public class Notifications.Bubble : AbstractBubble {
     }
 
     private void launch_action (string action_key) {
-        app_info.launch_action (action_key, new GLib.AppLaunchContext ());
+        notification.app_info.launch_action (action_key, new GLib.AppLaunchContext ());
         action_invoked (action_key);
         dismiss ();
     }
 
-    public void replace (string new_summary, string new_body, string? new_image_path) {
+    public void replace (Notifications.Notification new_notification) {
         start_timeout (4000);
 
-        var new_contents = new Contents (app_name, app_info, new_summary, app_icon, new_body, new_image_path);
+        var new_contents = new Contents (
+            new_notification.app_info,
+            new_notification.summary,
+            app_icon,
+            new_notification.body,
+            new_notification.image_path
+        );
         new_contents.show_all ();
 
         content_area.add (new_contents);
@@ -122,16 +113,14 @@ public class Notifications.Bubble : AbstractBubble {
     private class Contents : Gtk.Grid {
         public GLib.DesktopAppInfo? app_info { get; construct; }
         public string app_icon { get; construct; }
-        public string app_name { get; construct; }
         public string body { get; construct; }
         public string? image_path { get; construct; }
         public string summary { get; construct; }
 
-        public Contents (string app_name, GLib.DesktopAppInfo? app_info, string summary, string app_icon, string body, string? image_path) {
+        public Contents (GLib.DesktopAppInfo? app_info, string summary, string app_icon, string body, string? image_path) {
             Object (
                 app_icon: app_icon,
                 app_info: app_info,
-                app_name: app_name,
                 body: body,
                 image_path: image_path,
                 summary: summary
@@ -139,12 +128,6 @@ public class Notifications.Bubble : AbstractBubble {
         }
 
         construct {
-            /*Only summary is required by GLib, so try to set a title when body is empty*/
-            if (body == "") {
-                body = summary;
-                summary = app_name;
-            }
-
             if (app_icon == "") {
                 if (app_info != null) {
                     app_icon = app_info.get_icon ().to_string ();

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -113,54 +113,23 @@ public class Notifications.Server : Object {
         if (hints.contains (X_CANONICAL_PRIVATE_SYNCHRONOUS)) {
             send_confirmation (app_icon, hints);
         } else {
-            unowned Variant? variant = null;
+            var notification = new Notifications.Notification (app_name, summary, body, hints);
 
-            var priority = GLib.NotificationPriority.NORMAL;
-            if ((variant = hints.lookup ("urgency")) != null && variant.is_of_type (VariantType.BYTE)) {
-                priority = (GLib.NotificationPriority) variant.get_byte ();
-            }
-
-            if (!settings.get_boolean ("do-not-disturb") || priority == GLib.NotificationPriority.URGENT) {
-                string app_id = OTHER_APP_ID;
-                if ((variant = hints.lookup ("desktop-entry")) != null && variant.is_of_type (VariantType.STRING)) {
-                    app_id = variant.get_string ();
-                    app_id.replace (".desktop", "");
-                }
-
+            if (!settings.get_boolean ("do-not-disturb") || notification.priority == GLib.NotificationPriority.URGENT) {
                 var app_settings = new GLib.Settings.full (
                     SettingsSchemaSource.get_default ().lookup ("io.elementary.notifications.applications", true),
                     null,
-                    "/io/elementary/notifications/applications/%s/".printf (app_id)
+                    "/io/elementary/notifications/applications/%s/".printf (notification.app_id)
                 );
 
                 if (app_settings.get_boolean ("bubbles")) {
-                    string? image_path = null;
-                    if ((variant = hints.lookup ("image-path")) != null || (variant = hints.lookup ("image_path")) != null) {
-                        image_path = variant.get_string ();
-
-                        if (!image_path.has_prefix ("/") && !image_path.has_prefix ("file://")) {
-                            image_path = null;
-                        }
-                    }
-
                     if (bubbles.has_key (id) && bubbles[id] != null) {
-                        bubbles[id].replace (summary, body, image_path);
+                        bubbles[id].replace (notification);
                     } else {
-                        GLib.DesktopAppInfo? app_info = null;
-
-                        if (app_id != OTHER_APP_ID) {
-                            app_info = new DesktopAppInfo ("%s.desktop".printf (app_id));
-                        }
-
                         bubbles[id] = new Notifications.Bubble (
-                            app_info,
+                            notification,
                             app_icon,
-                            app_name,
-                            summary,
-                            body,
                             actions,
-                            priority,
-                            image_path,
                             id
                         );
                         bubbles[id].show_all ();

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -113,7 +113,7 @@ public class Notifications.Server : Object {
         if (hints.contains (X_CANONICAL_PRIVATE_SYNCHRONOUS)) {
             send_confirmation (app_icon, hints);
         } else {
-            var notification = new Notifications.Notification (app_name, summary, body, hints);
+            var notification = new Notifications.Notification (app_name, app_icon, summary, body, hints);
 
             if (!settings.get_boolean ("do-not-disturb") || notification.priority == GLib.NotificationPriority.URGENT) {
                 var app_settings = new GLib.Settings.full (
@@ -126,12 +126,7 @@ public class Notifications.Server : Object {
                     if (bubbles.has_key (id) && bubbles[id] != null) {
                         bubbles[id].replace (notification);
                     } else {
-                        bubbles[id] = new Notifications.Bubble (
-                            notification,
-                            app_icon,
-                            actions,
-                            id
-                        );
+                        bubbles[id] = new Notifications.Bubble (notification, actions, id);
                         bubbles[id].show_all ();
 
                         bubbles[id].action_invoked.connect ((action_key) => {

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -37,7 +37,6 @@ public class Notifications.Server : Object {
     public signal void notification_closed (uint32 id, uint32 reason);
 
     private const string X_CANONICAL_PRIVATE_SYNCHRONOUS = "x-canonical-private-synchronous";
-    private const string OTHER_APP_ID = "gala-other";
 
     private uint32 id_counter = 0;
     private unowned Canberra.Context? ca_context = null;

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -19,11 +19,13 @@
 */
 
 public class Notifications.Notification : GLib.Object {
+    private const string OTHER_APP_ID = "gala-other";
+
     public GLib.DesktopAppInfo? app_info { get; private set; default = null; }
     public GLib.NotificationPriority priority { get; private set; default = GLib.NotificationPriority.NORMAL; }
     public HashTable<string, Variant> hints { get; construct; }
     public string app_icon { get; construct; }
-    public string app_id { get; private set; default = "gala-other"; }
+    public string app_id { get; private set; default = OTHER_APP_ID; }
     public string app_name { get; construct; }
     public string body { get; construct set; }
     public string? image_path { get; private set; default = null; }

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -22,15 +22,17 @@ public class Notifications.Notification : GLib.Object {
     public GLib.DesktopAppInfo? app_info { get; private set; default = null; }
     public GLib.NotificationPriority priority { get; private set; default = GLib.NotificationPriority.NORMAL; }
     public HashTable<string, Variant> hints { get; construct; }
+    public string app_icon { get; construct; }
     public string app_id { get; private set; default = "gala-other"; }
     public string app_name { get; construct; }
     public string body { get; construct set; }
     public string? image_path { get; private set; default = null; }
     public string summary { get; construct set; }
 
-    public Notification (string app_name, string summary, string body, HashTable<string, Variant> hints) {
+    public Notification (string app_name, string app_icon, string summary, string body, HashTable<string, Variant> hints) {
         Object (
             app_name: app_name,
+            app_icon: app_icon,
             summary: summary,
             body: body,
             hints: hints
@@ -62,6 +64,14 @@ public class Notifications.Notification : GLib.Object {
 
             if (!image_path.has_prefix ("/") && !image_path.has_prefix ("file://")) {
                 image_path = null;
+            }
+        }
+
+        if (app_icon == "") {
+            if (app_info != null) {
+                app_icon = app_info.get_icon ().to_string ();
+            } else {
+                app_icon = "dialog-information";
             }
         }
     }

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -1,0 +1,68 @@
+/*
+* Copyright 2020 elementary, Inc. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+*/
+
+public class Notifications.Notification : GLib.Object {
+    public GLib.DesktopAppInfo? app_info { get; private set; default = null; }
+    public GLib.NotificationPriority priority { get; private set; default = GLib.NotificationPriority.NORMAL; }
+    public HashTable<string, Variant> hints { get; construct; }
+    public string app_id { get; private set; default = "gala-other"; }
+    public string app_name { get; construct; }
+    public string body { get; construct set; }
+    public string? image_path { get; private set; default = null; }
+    public string summary { get; construct set; }
+
+    public Notification (string app_name, string summary, string body, HashTable<string, Variant> hints) {
+        Object (
+            app_name: app_name,
+            summary: summary,
+            body: body,
+            hints: hints
+        );
+    }
+
+    construct {
+        /*Only summary is required by GLib, so try to set a title when body is empty*/
+        if (body == "") {
+            body = summary;
+            summary = app_name;
+        }
+
+        unowned Variant? variant = null;
+
+        if ((variant = hints.lookup ("urgency")) != null && variant.is_of_type (VariantType.BYTE)) {
+            priority = (GLib.NotificationPriority) variant.get_byte ();
+        }
+
+        if ((variant = hints.lookup ("desktop-entry")) != null && variant.is_of_type (VariantType.STRING)) {
+            app_id = variant.get_string ();
+            app_id.replace (".desktop", "");
+
+            app_info = new DesktopAppInfo ("%s.desktop".printf (app_id));
+        }
+
+        if ((variant = hints.lookup ("image-path")) != null || (variant = hints.lookup ("image_path")) != null) {
+            image_path = variant.get_string ();
+
+            if (!image_path.has_prefix ("/") && !image_path.has_prefix ("file://")) {
+                image_path = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
It's really a pain to pass around all these arguments and also it gets a bit confusing to see what's going on with all the translating/interpreting we're doing here. This creates a notification object like we use in the indicator to greatly improve legibility and make it a bit easier to get the right properties across the different classes

This also is gonna make actions easier and there's a couple of things that we're not properly doing on replace that will be easy to fix after this