### PR TITLE
Confirmation: Add flat class to Progressbar

### DIFF
--- a/src/Confirmation.vala
+++ b/src/Confirmation.vala
@@ -41,6 +41,7 @@ public class Notifications.Confirmation : AbstractBubble {
             margin_end = 6,
             width_request = 228
         };
+        progressbar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         var contents = new Gtk.Grid () {
             column_spacing = 6


### PR DESCRIPTION
We're currently relying on the stylesheet to special case progressbars inside of notifications, but this should really just be flat class