### PR TITLE
Use icon specified in set_icon

### DIFF
--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -20,6 +20,7 @@
 
 public class Notifications.Notification : GLib.Object {
     private const string OTHER_APP_ID = "gala-other";
+    private const int[] VALID_ICON_SIZES = {16, 24, 32, 48, 64, 128};
 
     public GLib.DesktopAppInfo? app_info { get; private set; default = null; }
     public GLib.NotificationPriority priority { get; private set; default = GLib.NotificationPriority.NORMAL; }
@@ -83,10 +84,11 @@ public class Notifications.Notification : GLib.Object {
 
             if (!image_path.has_prefix ("/") && !image_path.has_prefix ("file://")) {
                 /* app_icon should be set to image_path here if the image_path parameter
-                isn't a path to a file. Should try to find a way to check if an icon
-                is actually valid so if the icon string doesn't exist, we'll fallback
-                to dialog-information. */
-                app_icon = image_path;
+                isn't a path to a file. */
+                if (is_icon_exist (image_path)) {
+                    app_icon = image_path;
+                }
+
                 image_path = null;
             }
         }
@@ -114,5 +116,24 @@ public class Notifications.Notification : GLib.Object {
         }
 
         return text;
+    }
+
+    /**
+     * Check if an icon exists for all valid sizes.
+     */
+    private bool is_icon_exist (string icon_name) {
+        var icon_theme = Gtk.IconTheme.get_default ();
+        var icon = new ThemedIcon (icon_name);
+
+        Gtk.IconInfo? info;
+
+        foreach (var size in VALID_ICON_SIZES) {
+            info = icon_theme.lookup_by_gicon (icon, size, 0);
+
+            if (info == null)
+                return false;
+        }
+
+        return true;
     }
 }

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -82,6 +82,11 @@ public class Notifications.Notification : GLib.Object {
             image_path = variant.get_string ();
 
             if (!image_path.has_prefix ("/") && !image_path.has_prefix ("file://")) {
+                /* app_icon should be set to image_path here if the image_path parameter
+                isn't a path to a file. Should try to find a way to check if an icon
+                is actually valid so if the icon string doesn't exist, we'll fallback
+                to dialog-information. */
+                app_icon = image_path;
                 image_path = null;
             }
         }


### PR DESCRIPTION
Fixes #111

Defaults to `dialog-information` icon if icon is not valid for all sizes that elementary uses (16, 24, 32, 48, 64, 128).

To test:
```vala
// valac --pkg gtk+-3.0 Application.vala

public class Application : Gtk.Application {
    public Application () {
        Object (
            // Set icon to calculator so an icon does show
            application_id: "com.github.pongloongyeat.notification-test",
            flags: ApplicationFlags.FLAGS_NONE
        );
    }

    protected override void activate () {
        var notification = new Notification ("Test");
        notification.set_icon (new GLib.ThemedIcon ("application-pdf"));
        notification.set_body ("123");

        send_notification (application_id, notification);
    }

    public static int main (string[] args) {
        var app = new Application ();
        return app.run (args);
    }
}
```

Application should show a notification with the `dialog-information` icon on master, `application-pdf` icon with this PR. If you rename the icon name to something wrong ("application-df" for instance), you should get the default `dialog-information` icon.

![Screenshot from 2021-02-22 04-27-06](https://user-images.githubusercontent.com/31680656/108637573-50084d00-74c6-11eb-8035-a57f9f541999.png)
