### PR TITLE
Fix #117: Show icons for daemons

### DIFF
--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -76,6 +76,9 @@ public class Notifications.Notification : GLib.Object {
             app_id.replace (".desktop", "");
 
             app_info = new DesktopAppInfo ("%s.desktop".printf (app_id));
+            if (app_info == null) {
+                app_info = new DesktopAppInfo.from_filename ("/etc/xdg/autostart/%s.desktop".printf (app_id));
+            }
         }
 
         if ((variant = hints.lookup ("image-path")) != null || (variant = hints.lookup ("image_path")) != null) {


### PR DESCRIPTION
This PR adds a code change which loads a *.desktop file from `/etc/xdg/autostart` if available. This is needed for daemon processes which are automatically started in the background and are sending notifications to the user.

**Notification displayed before change**

![Screenshot from 2021-05-04 23-29-30](https://user-images.githubusercontent.com/392542/117249809-80fbeb00-ae42-11eb-86cb-d93e6bf6e0d8.png)

**Notification displayed after change**

![Screenshot from 2021-05-06 08-11-02](https://user-images.githubusercontent.com/392542/117249892-9ffa7d00-ae42-11eb-8785-fa69532536b6.png)
