### PR TITLE
Handle URIs used for application icons (#119)

### DIFF
--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -96,7 +96,7 @@ public class Notifications.Bubble : AbstractBubble {
     }
 
     static bool is_uri (string? uri) {
-        return uri.contains("/");
+        return uri.contains ("/");
     }
 
     static Gtk.Image get_app_image (string? icon_name, int pixel_size, int scale) {

--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -95,6 +95,28 @@ public class Notifications.Bubble : AbstractBubble {
         content_area.visible_child = new_contents;
     }
 
+    static bool is_uri (string? uri) {
+        return uri.contains("/");
+    }
+
+    static Gtk.Image get_app_image (string? icon_name, int pixel_size, int scale) {
+        Gtk.Image app_image = new Gtk.Image ();
+        if (is_uri (icon_name)) {
+            try {
+                var filename = GLib.Filename.from_uri (icon_name);
+                var pixbuf = new Gdk.Pixbuf.from_file_at_size (filename, pixel_size * scale, pixel_size * scale);
+                app_image.pixbuf = pixbuf;
+            } catch (Error e) {
+                critical ("Failed to generate app icon: %s", e.message);
+                app_image.icon_name = "image-missing";
+            }
+        } else {
+            app_image.icon_name = icon_name;
+        }
+        app_image.pixel_size = pixel_size;
+        return app_image;
+    }
+
     private class Contents : Gtk.Grid {
         public Notifications.Notification notification { get; construct; }
 
@@ -103,20 +125,17 @@ public class Notifications.Bubble : AbstractBubble {
         }
 
         construct {
-            var app_image = new Gtk.Image ();
-            app_image.icon_name = notification.app_icon;
-
             var image_overlay = new Gtk.Overlay ();
             image_overlay.valign = Gtk.Align.START;
 
+            var scale = get_style_context ().get_scale ();
             if (notification.image_path != null) {
                 try {
-                    var scale = get_style_context ().get_scale ();
                     var pixbuf = new Gdk.Pixbuf.from_file_at_size (notification.image_path, 48 * scale, 48 * scale);
 
                     var masked_image = new Notifications.MaskedImage (pixbuf);
 
-                    app_image.pixel_size = 24;
+                    var app_image = get_app_image (notification.app_icon, 24, scale);
                     app_image.halign = app_image.valign = Gtk.Align.END;
 
                     image_overlay.add (masked_image);
@@ -124,11 +143,11 @@ public class Notifications.Bubble : AbstractBubble {
                 } catch (Error e) {
                     critical ("Unable to mask image: %s", e.message);
 
-                    app_image.pixel_size = 48;
+                    var app_image = get_app_image (notification.app_icon, 48, scale);
                     image_overlay.add (app_image);
                 }
             } else {
-                app_image.pixel_size = 48;
+                var app_image = get_app_image (notification.app_icon, 48, scale);
                 image_overlay.add (app_image);
             }
 


### PR DESCRIPTION
This PR adds support for application icons defined as URIs instead of icon names. I tested it with an affected application (Google Chrome) as well as an unaffected one (Music) and both seem to work as expected. Please let me know if I need to make any adjustments.

Closes #119 