### PR TITLE
Revert "Fix #117: Show icons for daemons (#118)"

### DIFF
--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -76,9 +76,6 @@ public class Notifications.Notification : GLib.Object {
             app_id.replace (".desktop", "");
 
             app_info = new DesktopAppInfo ("%s.desktop".printf (app_id));
-            if (app_info == null) {
-                app_info = new DesktopAppInfo.from_filename ("/etc/xdg/autostart/%s.desktop".printf (app_id));
-            }
         }
 
         if ((variant = hints.lookup ("image-path")) != null || (variant = hints.lookup ("image_path")) != null) {


### PR DESCRIPTION
This reverts commit a6d20d5e825900ca37e54c06a4967c8f658ca70b.

>Please revert this. We shouldn't be loading desktop files from the autostart folder. This folder is *only* for desktop files that should be launched with the session (and they don't even need to be fully formed desktop files). Hence why this isn't in the standard lookup path for `DesktopAppInfo`.
>
>If something (a daemon or otherwise) wants to send notifications, it should install a desktop file to an XDG applications path (e.g. `/usr/share/applications`). If it should be hidden from the applications menu because it's a daemon, use the `NoDisplay` key.

_Originally posted by @davidmhewitt in https://github.com/elementary/notifications/issues/118#issuecomment-841344688_