### PR TITLE
Add support for sound-name and suppress-sound hints

### DIFF
--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -184,9 +184,16 @@ public class Notifications.Server : Object {
     }
 
     private void send_sound (HashTable<string,Variant> hints, string sound_name = "dialog-information") {
+        unowned Variant? variant = null;
+
+        if ((variant = hints.lookup ("suppress-sound")) != null && variant.is_of_type (VariantType.BOOLEAN) && variant.get_boolean ()) {
+            return;
+        }
+
         if (sound_name == "dialog-information") {
-            Variant? variant = hints.lookup ("category");
-            if (variant != null) {
+            if ((variant = hints.lookup ("sound-name")) != null && variant.is_of_type (VariantType.STRING)) {
+                sound_name = variant.get_string ();
+            } else if ((variant = hints.lookup ("category")) != null && variant.is_of_type (VariantType.STRING)) {
                 sound_name = category_to_sound_name (variant.get_string ());
             }
         }


### PR DESCRIPTION
The [notification specification](https://developer.gnome.org/notification-spec/#hints) defines some additional hints for sounds.

- sound-file
- sound-name
- suppress-sound

This PR adds support for sound-name and suppress-sound. Supporting sound-file may be a bit more involved since Canberra doesn't seem to natively support files.

Testing sound-name (and category to verify no breakage) can be done with `notify-send`:

```bash
# category
notify-send --category=email test test
notify-send --category=im.received test test

# sound-name
notify-send --hint=string:sound-name:message-new-instant test test
notify-send --hint=string:sound-name:service-login test test
```

Testing suppress-sound is trickier since notify-send doesn't support boolean hints.
```bash
gdbus call --session \
    --dest org.freedesktop.Notifications \
    --object-path /org/freedesktop/Notifications \
    --method org.freedesktop.Notifications.Notify \
    "test" "42" "dialog-information" "test" "test" \
    '[]' '{"suppress-sound":<true>}' "5000"
```