### PR TITLE
Notification: get app_name fallback from appinfo

### DIFF
--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -56,15 +56,6 @@ public class Notifications.Notification : GLib.Object {
     }
 
     construct {
-        /*Only summary is required by GLib, so try to set a title when body is empty*/
-        if (body == "") {
-            body = fix_markup (summary);
-            summary = app_name;
-        } else {
-            body = fix_markup (body);
-            summary = fix_markup (summary);
-        }
-
         unowned Variant? variant = null;
 
         if ((variant = hints.lookup ("urgency")) != null && variant.is_of_type (VariantType.BYTE)) {
@@ -95,6 +86,19 @@ public class Notifications.Notification : GLib.Object {
             } else {
                 app_icon = "dialog-information";
             }
+        }
+
+        if (app_name == "" && app_info != null) {
+            app_name = app_info.get_display_name ();
+        }
+
+        /*Only summary is required by GLib, so try to set a title when body is empty*/
+        if (body == "") {
+            body = fix_markup (summary);
+            summary = app_name;
+        } else {
+            body = fix_markup (body);
+            summary = fix_markup (summary);
         }
     }
 


### PR DESCRIPTION
Discovered while testing GNOME Clocks. If `app_name` and `body` are both blank, we get a missing notification title. Adds a fallback for app_name to check app_info