### PR TITLE
Bubble: wrap between characters if needed

### DIFF
--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -165,6 +165,7 @@ public class Notifications.Bubble : AbstractBubble {
                 valign = Gtk.Align.START,
                 width_chars = 33,
                 wrap = true,
+                wrap_mode = Pango.WrapMode.WORD_CHAR,
                 xalign = 0
             };
 


### PR DESCRIPTION
Fixes #131. To test:

- send a notification with a long, one-word body like `aaaaaaabbbbbbbcccccccdddddddeeeeeeefffffffggggggg`
- double-check with a more regular notification like `This is a normal, long notification test. Things should wrap at the natural word boundaries as you'd expect.`