### PR TITLE
Add a badge with set_icon

### DIFF
--- a/demo/MainWindow.vala
+++ b/demo/MainWindow.vala
@@ -23,6 +23,7 @@
 public class MainWindow : Gtk.ApplicationWindow {
     private Gtk.Entry title_entry;
     private Gtk.Entry body_entry;
+    private Gtk.Entry icon_entry;
     private Gtk.Entry id_entry;
     private Gtk.ComboBoxText priority_combobox;
     private Gtk.SpinButton action_spinbutton;
@@ -50,6 +51,11 @@ public class MainWindow : Gtk.ApplicationWindow {
         id_entry = new Gtk.Entry () {
             activates_default = true,
             placeholder_text = "Replaces Id"
+        };
+
+        icon_entry = new Gtk.Entry () {
+            activates_default = true,
+            placeholder_text = "Badge Icon Name"
         };
 
         var priority_label = new Gtk.Label ("Priority:");
@@ -83,11 +89,12 @@ public class MainWindow : Gtk.ApplicationWindow {
         grid.attach (title_entry, 0, 0, 2);
         grid.attach (body_entry, 0, 1, 2);
         grid.attach (id_entry, 0, 2, 2);
-        grid.attach (priority_label, 0, 3);
-        grid.attach (priority_combobox, 1, 3);
-        grid.attach (action_label, 0, 4);
-        grid.attach (action_spinbutton, 1, 4);
-        grid.attach (send_button, 0, 5, 2);
+        grid.attach (icon_entry, 0, 3, 2);
+        grid.attach (priority_label, 0, 4);
+        grid.attach (priority_combobox, 1, 4);
+        grid.attach (action_label, 0, 5);
+        grid.attach (action_spinbutton, 1, 5);
+        grid.attach (send_button, 0, 6, 2);
 
         var toast = new Granite.Widgets.Toast ("");
 
@@ -140,6 +147,10 @@ public class MainWindow : Gtk.ApplicationWindow {
         }
 
         string? id = id_entry.text.length == 0 ? null : id_entry.text;
+
+        if (icon_entry.text != "") {
+            notification.set_icon (new ThemedIcon (icon_entry.text));
+        }
 
         application.send_notification (id, notification);
     }

--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -146,6 +146,15 @@ public class Notifications.Bubble : AbstractBubble {
             } else {
                 app_image.pixel_size = 48;
                 image_overlay.add (app_image);
+
+                if (notification.badge_icon != null) {
+                    var badge_image = new Gtk.Image.from_gicon (notification.badge_icon, Gtk.IconSize.LARGE_TOOLBAR) {
+                        halign = Gtk.Align.END,
+                        valign = Gtk.Align.END,
+                        pixel_size = 24
+                    };
+                    image_overlay.add_overlay (badge_image);
+                }
             }
 
             var title_label = new Gtk.Label (notification.summary) {

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -93,7 +93,7 @@ public class Notifications.Notification : GLib.Object {
             }
 
             var is_a_path = image_path.has_prefix ("/") || image_path.has_prefix ("file://");
-            if (badge_icon != null || image_path == app_icon || !is_a_path) {
+            if (badge_icon != null || !is_a_path) {
                 image_path = null;
             }
         }


### PR DESCRIPTION
While we don't want apps misrepresenting themselves by removing their own automatically set icon, we can allow them to be more expressive by setting a badge via `Notification.set_icon ()`

* Added some comments so its more clear how what we get from DBus matches GLib.Notification
* If we get an icon name via the `image-path` hint, and its not the app icon name, create a badge icon for it

Looks like:
![Screenshot from 2021-06-03 13 26 22](https://user-images.githubusercontent.com/7277719/120707666-7a778800-c46f-11eb-9b4f-41f2fdcf0916.png)
