### PR TITLE
Move Image/Icon logic to Notification class

### DIFF
--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -109,40 +109,19 @@ public class Notifications.Bubble : AbstractBubble {
         }
 
         construct {
-            var app_image = new Gtk.Image ();
-
-            if (notification.app_icon.contains ("/")) {
-                var file = File.new_for_uri (notification.app_icon);
-                if (file.query_exists ()) {
-                    app_image.gicon = new FileIcon (file);
-                } else {
-                    app_image.icon_name = "dialog-information";
-                }
-            } else {
-                app_image.icon_name = notification.app_icon;
-            }
+            var app_image = new Gtk.Image () {
+                gicon = notification.primary_icon
+            };
 
             var image_overlay = new Gtk.Overlay ();
             image_overlay.valign = Gtk.Align.START;
 
-            if (notification.image_path != null) {
-                try {
-                    var scale = get_style_context ().get_scale ();
-                    var pixbuf = new Gdk.Pixbuf.from_file_at_size (notification.image_path, 48 * scale, 48 * scale);
+            if (notification.image != null) {
+                app_image.pixel_size = 24;
+                app_image.halign = app_image.valign = Gtk.Align.END;
 
-                    var masked_image = new Notifications.MaskedImage (pixbuf);
-
-                    app_image.pixel_size = 24;
-                    app_image.halign = app_image.valign = Gtk.Align.END;
-
-                    image_overlay.add (masked_image);
-                    image_overlay.add_overlay (app_image);
-                } catch (Error e) {
-                    critical ("Unable to mask image: %s", e.message);
-
-                    app_image.pixel_size = 48;
-                    image_overlay.add (app_image);
-                }
+                image_overlay.add (notification.image);
+                image_overlay.add_overlay (app_image);
             } else {
                 app_image.pixel_size = 48;
                 image_overlay.add (app_image);

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -98,10 +98,8 @@ public class Notifications.Notification : GLib.Object {
             if (Gtk.IconTheme.get_default ().has_icon (image_path) && image_path != app_icon) {
                 badge_icon = new ThemedIcon (image_path);
             } else if (image_path.has_prefix ("/") || image_path.has_prefix ("file://")) {
-                var scale = ((Gtk.Application) GLib.Application.get_default ()).get_active_window ().get_style_context ().get_scale ();
-
                 try {
-                    var pixbuf = new Gdk.Pixbuf.from_file_at_size (image_path, 48 * scale, 48 * scale);
+                    var pixbuf = new Gdk.Pixbuf.from_file (image_path);
                     image = new Notifications.MaskedImage (pixbuf);
                 } catch (Error e) {
                     critical ("Unable to mask image: %s", e.message);

--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -29,9 +29,11 @@ public class Notifications.Notification : GLib.Object {
     public string app_id { get; private set; default = OTHER_APP_ID; }
     public string app_name { get; construct; }
     public string body { get; construct set; }
-    public string? image_path { get; private set; default = null; }
     public string summary { get; construct set; }
-    public GLib.Icon badge_icon { get; construct set; }
+
+    public GLib.Icon? primary_icon { get; set; default = null; }
+    public GLib.Icon? badge_icon { get; set; default = null; }
+    public MaskedImage? image { get; set; default = null; }
 
     private static Regex entity_regex;
     private static Regex tag_regex;
@@ -75,26 +77,35 @@ public class Notifications.Notification : GLib.Object {
         }
 
         // Always "" if sent by GLib.Notification
-        if (app_icon == "") {
-            if (app_info != null) {
-                app_icon = app_info.get_icon ().to_string ();
-            } else {
-                app_icon = "dialog-information";
+        if (app_icon == "" && app_info != null) {
+            primary_icon = app_info.get_icon ();
+        } else if (app_icon.contains ("/")) {
+            var file = File.new_for_uri (app_icon);
+            if (file.query_exists ()) {
+                primary_icon = new FileIcon (file);
             }
+        }
+
+        if (primary_icon == null) {
+            primary_icon = new ThemedIcon ("dialog-information");
         }
 
         // GLib.Notification.set_icon ()
         if ((variant = hints.lookup ("image-path")) != null || (variant = hints.lookup ("image_path")) != null) {
-            image_path = variant.get_string ();
+            var image_path = variant.get_string ();
 
             // GLib.Notification also sends icon names via this hint
             if (Gtk.IconTheme.get_default ().has_icon (image_path) && image_path != app_icon) {
                 badge_icon = new ThemedIcon (image_path);
-            }
+            } else if (image_path.has_prefix ("/") || image_path.has_prefix ("file://")) {
+                var scale = ((Gtk.Application) GLib.Application.get_default ()).get_active_window ().get_style_context ().get_scale ();
 
-            var is_a_path = image_path.has_prefix ("/") || image_path.has_prefix ("file://");
-            if (badge_icon != null || !is_a_path) {
-                image_path = null;
+                try {
+                    var pixbuf = new Gdk.Pixbuf.from_file_at_size (image_path, 48 * scale, 48 * scale);
+                    image = new Notifications.MaskedImage (pixbuf);
+                } catch (Error e) {
+                    critical ("Unable to mask image: %s", e.message);
+                }
             }
         }
 


### PR DESCRIPTION
This is all getting pretty complicated and #123 would make it even more complicated. This branch moves more of the image/icon logic to `Notification` so that `Bubble` can be pretty straightforward. It also makes fallbacks more straightforward to implement

* Add a new property `primary_icon`. Notification server clients try to either give us a gicon from appinfo, an icon name, or a path to an icon. All of these can be handled by GIcon, so this lets us set a single property instead of having Bubble try to create an image by null checking several properties
* Add a new property `image`. There are two ways clients could try to set an image: file path or (in the future) image data. This lets `Bubble` check for a single property to see if a `MaskedImage` has been created or not.
* The `dialog-information` fallback is now handled in Notification only instead of both in `Bubble` and `Notification`
* We no longer need to reset `image_path` to null since `Bubble` only checks for a `MaskedImage`
* Masked image already scales pixbufs sent into it afaict, so we don't need to scale before passing the pixbuf in