### PR TITLE
Stop processing click events once dismissed (fixes #141)

### DIFF
--- a/src/AbstractBubble.vala
+++ b/src/AbstractBubble.vala
@@ -24,6 +24,7 @@ public class Notifications.AbstractBubble : Gtk.Window {
     protected Gtk.Stack content_area;
     protected Gtk.HeaderBar headerbar;
     protected Gtk.Grid draw_area;
+    protected bool dismissed;
 
     private Gtk.Revealer revealer;
     private uint timeout_id;
@@ -146,6 +147,7 @@ public class Notifications.AbstractBubble : Gtk.Window {
     }
 
     public void dismiss () {
+        dismissed = true;
         revealer.reveal_child = false;
         GLib.Timeout.add (revealer.transition_duration, () => {
             destroy ();

--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -62,7 +62,9 @@ public class Notifications.Bubble : AbstractBubble {
         });
 
         button_release_event.connect ((event) => {
-            if (default_action) {
+            if (dismissed) {
+                // Process no more events
+            } else if (default_action) {
                 action_invoked ("default");
                 dismiss ();
             } else if (notification.app_info != null && !has_actions) {


### PR DESCRIPTION
Once the notification is dismissed, set a flag to stop processing further events. This is really only needed for action handling, as found in #141 