### PR TITLE
Port to GTK4

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,13 +23,15 @@ executable(
     'src/Widgets/MaskedImage.vala',
     css_gresource,
     dependencies: [
-        dependency ('libcanberra'),
-        dependency ('libcanberra-gtk3'),
+        # dependency ('libcanberra'),
+        # dependency ('libcanberra-gtk3'),
+        dependency ('gee-0.8'),
+        dependency ('gio-unix-2.0'),
         dependency ('glib-2.0'),
         dependency ('gobject-2.0'),
-        dependency ('granite', version: '>=5.4.0'),
-        dependency ('gtk+-3.0'),
-        dependency ('libhandy-1')
+        # dependency ('granite', version: '>=5.4.0'),
+        dependency ('gtk4'),
+        dependency ('libadwaita-1')
     ],
     install : true
 )

--- a/src/AbstractBubble.vala
+++ b/src/AbstractBubble.vala
@@ -27,7 +27,7 @@ public class Notifications.AbstractBubble : Gtk.Window {
 
     private Gtk.Revealer revealer;
     private uint timeout_id;
-    private Hdy.Carousel carousel;
+    private Adw.Carousel carousel;
 
     construct {
         content_area = new Gtk.Stack () {
@@ -69,7 +69,7 @@ public class Notifications.AbstractBubble : Gtk.Window {
 
         var label = new Gtk.Grid ();
 
-        carousel = new Hdy.Carousel () {
+        carousel = new Adw.Carousel () {
             allow_mouse_drag = true,
             interactive = true,
             halign = Gtk.Align.END,


### PR DESCRIPTION
Initial port to GTK4 to see where we are blocked.

Depends on Granite
Where we are blocked:
- [ ] Libcanberra is deprecated
- [ ] Replace instances of Grid with Box and pack_start
- [ ] Replace instances of add with property child when possible