### PR TITLE
Replace `add` with `attach` for Grid

### DIFF
--- a/src/AbstractBubble.vala
+++ b/src/AbstractBubble.vala
@@ -40,7 +40,7 @@ public class Notifications.AbstractBubble : Gtk.Window {
             margin = 16
         };
         draw_area.get_style_context ().add_class ("draw-area");
-        draw_area.add (content_area);
+        draw_area.attach (content_area, 0, 0);
 
         var close_button = new Gtk.Button.from_icon_name ("window-close-symbolic", Gtk.IconSize.LARGE_TOOLBAR) {
             halign = Gtk.Align.START,


### PR DESCRIPTION
Since in GTK4, we cannot simply use the `add` command to add widgets to Grid anymore, we should use `attach`.