### PR TITLE
Remove Unused Value-returning Function

### DIFF
--- a/src/Widgets/MaskedImage.vala
+++ b/src/Widgets/MaskedImage.vala
@@ -40,26 +40,4 @@ public class Notifications.MaskedImage : Gtk.Overlay {
         add (image);
         add_overlay (mask);
     }
-
-    private static Gdk.Pixbuf? mask_pixbuf (Gdk.Pixbuf pixbuf, int scale) {
-        var size = ICON_SIZE * scale;
-        var mask_offset = 4 * scale;
-        var mask_size_offset = mask_offset * 2;
-        var mask_size = ICON_SIZE * scale;
-        var offset_x = mask_offset;
-        var offset_y = mask_offset + scale;
-        size = size - mask_size_offset;
-
-        var input = pixbuf.scale_simple (size, size, Gdk.InterpType.BILINEAR);
-        var surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, mask_size, mask_size);
-        var cr = new Cairo.Context (surface);
-
-        Granite.Drawing.Utilities.cairo_rounded_rectangle (cr, offset_x, offset_y, size, size, mask_offset);
-        cr.clip ();
-
-        Gdk.cairo_set_source_pixbuf (cr, input, offset_x, offset_y);
-        cr.paint ();
-
-        return Gdk.pixbuf_get_from_surface (surface, 0, 0, mask_size, mask_size);
-    }
 }


### PR DESCRIPTION
Value returning function `image_mask` is not unused so it can be deleted.