### PR TITLE
Allow control of unlisted applications.

### DIFF
--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -45,7 +45,7 @@ public class Notifications.Server : Object {
     private GLib.Settings settings;
 
     private Gee.HashMap<uint32, Notifications.Bubble> bubbles;
-    
+
     private List<string> valid_apps;
 
     construct {
@@ -59,21 +59,20 @@ public class Notifications.Server : Object {
         settings = new GLib.Settings ("io.elementary.notifications");
         bubbles = new Gee.HashMap<uint32, Notifications.Bubble> ();
         valid_apps = new List<string> ();
-        
+
         // Obtain a list of applications in a similar way to NotifyManager.
         var installed_apps = AppInfo.get_all ();
-    
+
         foreach (AppInfo app_info in installed_apps) {
             DesktopAppInfo? desktop_app_info = app_info as DesktopAppInfo;
 
             if (desktop_app_info != null && desktop_app_info.get_boolean ("X-GNOME-UsesNotifications")) {
                 var temp_name = app_info.get_id ();
-                
-                if (temp_name.has_suffix(".desktop")) {
-                    temp_name = temp_name.substring(0,temp_name.length-8);
+
+                if (temp_name.has_suffix (".desktop")) {
+                    temp_name = temp_name.substring (0, temp_name.length-8);
                 }
-                
-                valid_apps.append(temp_name);
+                valid_apps.append (temp_name);
             }
         }
     }
@@ -131,14 +130,14 @@ public class Notifications.Server : Object {
             var notification = new Notifications.Notification (app_name, app_icon, summary, body, actions, hints);
 
             if (!settings.get_boolean ("do-not-disturb") || notification.priority == GLib.NotificationPriority.URGENT) {
-                
+
                 var temp_app_id = notification.app_id;
-	            var vaild_application_id = false;
-	            
-	            valid_apps.foreach ((entry) => {
-	                if (entry == temp_app_id) {
-	                    vaild_application_id = true;
-	                }
+                var vaild_application_id = false;
+
+                valid_apps.foreach ((entry) => {
+                    if (entry == temp_app_id) {
+                        vaild_application_id = true;
+                    }
                 });
 
                 // Override the application id to "Other" if it does not exist as an
@@ -146,7 +145,7 @@ public class Notifications.Server : Object {
                 if (!vaild_application_id) {
                     temp_app_id = "gala-other";
                 }
-                
+
                 var app_settings = new GLib.Settings.full (
                     SettingsSchemaSource.get_default ().lookup ("io.elementary.notifications.applications", true),
                     null,

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -46,8 +46,6 @@ public class Notifications.Server : Object {
 
     private Gee.HashMap<uint32, Notifications.Bubble> bubbles;
 
-    private List<string> valid_apps;
-
     construct {
         try {
             bus_proxy = Bus.get_proxy_sync (BusType.SESSION, "org.freedesktop.DBus", "/");
@@ -58,23 +56,6 @@ public class Notifications.Server : Object {
 
         settings = new GLib.Settings ("io.elementary.notifications");
         bubbles = new Gee.HashMap<uint32, Notifications.Bubble> ();
-        valid_apps = new List<string> ();
-
-        // Obtain a list of applications in a similar way to NotifyManager.
-        var installed_apps = AppInfo.get_all ();
-
-        foreach (AppInfo app_info in installed_apps) {
-            DesktopAppInfo? desktop_app_info = app_info as DesktopAppInfo;
-
-            if (desktop_app_info != null && desktop_app_info.get_boolean ("X-GNOME-UsesNotifications")) {
-                var temp_name = app_info.get_id ();
-
-                if (temp_name.has_suffix (".desktop")) {
-                    temp_name = temp_name.substring (0, temp_name.length - 8);
-                }
-                valid_apps.append (temp_name);
-            }
-        }
     }
 
     public void close_notification (uint32 id) throws DBusError, IOError {

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -45,6 +45,8 @@ public class Notifications.Server : Object {
     private GLib.Settings settings;
 
     private Gee.HashMap<uint32, Notifications.Bubble> bubbles;
+    
+    private List<string> valid_apps;
 
     construct {
         try {
@@ -56,6 +58,24 @@ public class Notifications.Server : Object {
 
         settings = new GLib.Settings ("io.elementary.notifications");
         bubbles = new Gee.HashMap<uint32, Notifications.Bubble> ();
+        valid_apps = new List<string> ();
+        
+        // Obtain a list of applications in a similar way to NotifyManager.
+        var installed_apps = AppInfo.get_all ();
+    
+        foreach (AppInfo app_info in installed_apps) {
+            DesktopAppInfo? desktop_app_info = app_info as DesktopAppInfo;
+
+            if (desktop_app_info != null && desktop_app_info.get_boolean ("X-GNOME-UsesNotifications")) {
+                var temp_name = app_info.get_id ();
+                
+                if (temp_name.has_suffix(".desktop")) {
+                    temp_name = temp_name.substring(0,temp_name.length-8);
+                }
+                
+                valid_apps.append(temp_name);
+            }
+        }
     }
 
     public void close_notification (uint32 id) throws DBusError, IOError {
@@ -111,10 +131,26 @@ public class Notifications.Server : Object {
             var notification = new Notifications.Notification (app_name, app_icon, summary, body, actions, hints);
 
             if (!settings.get_boolean ("do-not-disturb") || notification.priority == GLib.NotificationPriority.URGENT) {
+                
+                var temp_app_id = notification.app_id;
+	            var vaild_application_id = false;
+	            
+	            valid_apps.foreach ((entry) => {
+	                if (entry == temp_app_id) {
+	                    vaild_application_id = true;
+	                }
+                });
+
+                // Override the application id to "Other" if it does not exist as an
+                // application that is displayed in the switchboard.
+                if (!vaild_application_id) {
+                    temp_app_id = "gala-other";
+                }
+                
                 var app_settings = new GLib.Settings.full (
                     SettingsSchemaSource.get_default ().lookup ("io.elementary.notifications.applications", true),
                     null,
-                    "/io/elementary/notifications/applications/%s/".printf (notification.app_id)
+                    "/io/elementary/notifications/applications/%s/".printf (temp_app_id)
                 );
 
                 if (app_settings.get_boolean ("bubbles")) {

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -70,7 +70,7 @@ public class Notifications.Server : Object {
                 var temp_name = app_info.get_id ();
 
                 if (temp_name.has_suffix (".desktop")) {
-                    temp_name = temp_name.substring (0, temp_name.length-8);
+                    temp_name = temp_name.substring (0, temp_name.length - 8);
                 }
                 valid_apps.append (temp_name);
             }

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -130,26 +130,14 @@ public class Notifications.Server : Object {
             var notification = new Notifications.Notification (app_name, app_icon, summary, body, actions, hints);
 
             if (!settings.get_boolean ("do-not-disturb") || notification.priority == GLib.NotificationPriority.URGENT) {
-
-                var temp_app_id = notification.app_id;
-                var vaild_application_id = false;
-
-                valid_apps.foreach ((entry) => {
-                    if (entry == temp_app_id) {
-                        vaild_application_id = true;
-                    }
-                });
-
-                // Override the application id to "Other" if it does not exist as an
-                // application that is displayed in the switchboard.
-                if (!vaild_application_id) {
-                    temp_app_id = "gala-other";
+                var app_id = notification.app_id;
+                if (notification.app_info == null || notification.app_info.get_boolean ("X-GNOME-UsesNotifications") == false) {
+                    app_id = "gala-other";
                 }
-
                 var app_settings = new GLib.Settings.full (
                     SettingsSchemaSource.get_default ().lookup ("io.elementary.notifications.applications", true),
                     null,
-                    "/io/elementary/notifications/applications/%s/".printf (temp_app_id)
+                    "/io/elementary/notifications/applications/%s/".printf (app_id)
                 );
 
                 if (app_settings.get_boolean ("bubbles")) {


### PR DESCRIPTION
Applications that are not listed in the switchboard are unable to have their notification settings changed. This checks that list and overrides the application id to "Other" if it is not present, allowing them to behave as expected as an "Other" application.