### PR TITLE
AbstractBubble: Handle Timeout internally

### DIFF
--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -42,7 +42,7 @@ public class Notifications.Bubble : AbstractBubble {
                 content_area.get_style_context ().add_class ("urgent");
                 break;
             default:
-                start_timeout (4000);
+                timeout = 4000;
                 break;
         }
 
@@ -58,17 +58,17 @@ public class Notifications.Bubble : AbstractBubble {
 
         contents.action_invoked.connect ((action_key) => {
             action_invoked (action_key);
-            dismiss ();
+            close ();
         });
 
         button_release_event.connect ((event) => {
             if (default_action) {
                 action_invoked ("default");
-                dismiss ();
+                close ();
             } else if (notification.app_info != null && !has_actions) {
                 try {
                     notification.app_info.launch (null, null);
-                    dismiss ();
+                    close ();
                 } catch (Error e) {
                     critical ("Unable to launch app: %s", e.message);
                 }
@@ -76,24 +76,15 @@ public class Notifications.Bubble : AbstractBubble {
 
             return Gdk.EVENT_STOP;
         });
-
-        leave_notify_event.connect (() => {
-            if (notification.priority == GLib.NotificationPriority.HIGH || notification.priority == GLib.NotificationPriority.URGENT) {
-                return Gdk.EVENT_PROPAGATE;
-            }
-            start_timeout (4000);
-        });
     }
 
     public void replace (Notifications.Notification new_notification) {
-        start_timeout (4000);
-
         var new_contents = new Contents (new_notification);
         new_contents.show_all ();
 
         new_contents.action_invoked.connect ((action_key) => {
             action_invoked (action_key);
-            dismiss ();
+            close ();
         });
 
         content_area.add (new_contents);

--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -24,6 +24,8 @@ public class Notifications.Bubble : AbstractBubble {
     public Notifications.Notification notification { get; construct; }
     public uint32 id { get; construct; }
 
+    private Gtk.GestureMultiPress press_gesture;
+
     public Bubble (Notifications.Notification notification, uint32 id) {
         Object (
             notification: notification,
@@ -61,7 +63,10 @@ public class Notifications.Bubble : AbstractBubble {
             close ();
         });
 
-        button_release_event.connect ((event) => {
+        press_gesture = new Gtk.GestureMultiPress (this) {
+            propagation_phase = BUBBLE
+        };
+        press_gesture.released.connect (() => {
             if (default_action) {
                 action_invoked ("default");
                 close ();
@@ -74,7 +79,7 @@ public class Notifications.Bubble : AbstractBubble {
                 }
             }
 
-            return Gdk.EVENT_STOP;
+            press_gesture.set_state (CLAIMED);
         });
     }
 

--- a/src/Confirmation.vala
+++ b/src/Confirmation.vala
@@ -25,7 +25,8 @@ public class Notifications.Confirmation : AbstractBubble {
     public Confirmation (string icon_name, double progress) {
         Object (
             icon_name: icon_name,
-            progress: progress
+            progress: progress,
+            timeout: 2000
         );
     }
 
@@ -55,15 +56,5 @@ public class Notifications.Confirmation : AbstractBubble {
 
         bind_property ("icon-name", image, "icon-name");
         bind_property ("progress", progressbar, "fraction");
-
-        notify["progress"].connect (() => {
-            stop_timeout ();
-            start_timeout (2000);
-        });
-
-        leave_notify_event.connect (() => {
-            start_timeout (2000);
-            return Gdk.EVENT_PROPAGATE;
-        });
     }
 }

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -60,7 +60,7 @@ public class Notifications.Server : Object {
 
     public void close_notification (uint32 id) throws DBusError, IOError {
         if (bubbles.has_key (id)) {
-            bubbles[id].dismiss ();
+            bubbles[id].close ();
             closed_callback (id, CloseReason.CLOSE_NOTIFICATION_CALL);
             return;
         }
@@ -138,7 +138,6 @@ public class Notifications.Server : Object {
                         bubbles[id].replace (notification);
                     } else {
                         bubbles[id] = new Notifications.Bubble (notification, id);
-                        bubbles[id].show_all ();
 
                         bubbles[id].action_invoked.connect ((action_key) => {
                             action_invoked (id, action_key);
@@ -148,6 +147,8 @@ public class Notifications.Server : Object {
                             closed_callback (id, reason);
                         });
                     }
+
+                    bubbles[id].present ();
                 }
 
                 if (app_settings.get_boolean ("sounds")) {
@@ -201,7 +202,7 @@ public class Notifications.Server : Object {
             confirmation.progress = progress_value;
         }
 
-        confirmation.show_all ();
+        confirmation.present ();
     }
 
     private void send_sound (HashTable<string,Variant> hints, string sound_name = "dialog-information") {


### PR DESCRIPTION
DRY the rest of the timeout logic that was still done in the subclasses back to the AbstractBubble class. Now the timeout is started when the notification is presented and resulting in longer bubbles. This also changes an possibly unwanted behaviour in the case of urgent notifications getting expired after hovering over them.

While here, also do a little of cleanup and preparation for Gtk4.