### PR TITLE
Add a new DBus method to emit the ActionInvoked signal from a third party app

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -31,9 +31,11 @@ public class Notifications.Application : Gtk.Application {
 
     protected override bool dbus_register (DBusConnection connection, string object_path) throws Error {
         var server = new Notifications.Server ();
+        var manager = new Notifications.Manager (server);
 
         try {
             connection.register_object ("/org/freedesktop/Notifications", server);
+            connection.register_object (object_path, manager);
         } catch (Error e) {
             warning ("Registring notification server failed: %s", e.message);
             throw e;

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -265,3 +265,16 @@ public class Notifications.Server : Object {
         return sound;
     }
 }
+
+[DBus (name = "io.elementary.Notifications")]
+public class Notifications.Manager : Object {
+    private Notifications.Server server;
+
+    public Manager (Server server) {
+        this.server = server;
+    }
+
+    public void invoke_action (uint32 id, string action) throws DBusError, IOError {
+        server.action_invoked (id, action);
+    }
+}


### PR DESCRIPTION
- I'm not sure whether this is the best way but for why I think it is needed see elementary/wingpanel-indicator-notifications#258
- Any better naming suggestions or better places to move this method? Should I integrate it in the `Server` class?