### PR TITLE
Bubble: minor refactor

### DIFF
--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -1,36 +1,17 @@
 /*
-* Copyright 2019-2020 elementary, Inc. (https://elementary.io)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*
-*/
+ * Copyright 2019-2023 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
 public class Notifications.Bubble : AbstractBubble {
     public signal void action_invoked (string action_key);
 
     public Notifications.Notification notification { get; construct; }
-    public uint32 id { get; construct; }
 
     private Gtk.GestureMultiPress press_gesture;
 
-    public Bubble (Notifications.Notification notification, uint32 id) {
-        Object (
-            notification: notification,
-            id: id
-        );
+    public Bubble (Notification notification) {
+        Object (notification: notification);
     }
 
     construct {

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -137,7 +137,7 @@ public class Notifications.Server : Object {
                     if (bubbles.has_key (id) && bubbles[id] != null) {
                         bubbles[id].replace (notification);
                     } else {
-                        bubbles[id] = new Notifications.Bubble (notification, id);
+                        bubbles[id] = new Bubble (notification);
 
                         bubbles[id].action_invoked.connect ((action_key) => {
                             action_invoked (id, action_key);

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -135,7 +135,7 @@ public class Notifications.Server : Object {
 
                 if (app_settings.get_boolean ("bubbles")) {
                     if (bubbles.has_key (id) && bubbles[id] != null) {
-                        bubbles[id].replace (notification);
+                        bubbles[id].notification = notification;
                     } else {
                         bubbles[id] = new Bubble (notification);
 


### PR DESCRIPTION
remove the `replace()` method and `construct` block in favor of construct the contents widget in one place. we also stop checking if the notification has no action for launching the application, instead we launch it whenever we don't have a default action.

Fixes some cases of #195/#145.
Fixes: #170