### PR TITLE
Fix block of "Automatic suspend" notifications

### DIFF
--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -83,7 +83,6 @@ public class Notifications.Server : Object {
         && app_icon == ""
         && expire_timeout == 0
         ) {
-
             debug ("Blocked GSD notification");
             throw new DBusError.FAILED ("Notification Blocked");
         }

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -79,10 +79,11 @@ public class Notifications.Server : Object {
         // See: https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/blob/master/plugins/power/gsd-power-manager.c#L356
         // We must check for app_icon == "" to not block low power notifications
         if ("desktop-entry" in hints && hints["desktop-entry"].get_string () == "gnome-power-panel"
-        && "urgency" in hints && hints["urgency"].get_byte () == 3
+        && "urgency" in hints && hints["urgency"].get_byte () == 2
         && app_icon == ""
         && expire_timeout == 0
         ) {
+
             debug ("Blocked GSD notification");
             throw new DBusError.FAILED ("Notification Blocked");
         }


### PR DESCRIPTION
This got broken in https://github.com/elementary/notifications/pull/201.