### PR TITLE
Handle Notification Hints in the Server

### DIFF
--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -81,31 +81,26 @@ public class Notifications.Bubble : AbstractBubble {
         }
 
         construct {
-            var app_image = new Gtk.Image () {
-                gicon = notification.primary_icon
+            var image_overlay = new Gtk.Overlay () {
+                valign = START
             };
 
-            var image_overlay = new Gtk.Overlay ();
-            image_overlay.valign = Gtk.Align.START;
-
-            if (notification.image != null) {
-                app_image.pixel_size = 24;
-                app_image.halign = app_image.valign = Gtk.Align.END;
-
-                image_overlay.add (notification.image);
-                image_overlay.add_overlay (app_image);
+            if (notification.image is LoadableIcon) {
+                image_overlay.child = new MaskedImage ((LoadableIcon) notification.image);
             } else {
-                app_image.pixel_size = 48;
-                image_overlay.add (app_image);
+                image_overlay.child = new Gtk.Image.from_gicon (notification.image, DIALOG) {
+                    pixel_size = 48
+                };
+            }
 
-                if (notification.badge_icon != null) {
-                    var badge_image = new Gtk.Image.from_gicon (notification.badge_icon, Gtk.IconSize.LARGE_TOOLBAR) {
-                        halign = Gtk.Align.END,
-                        valign = Gtk.Align.END,
-                        pixel_size = 24
-                    };
-                    image_overlay.add_overlay (badge_image);
-                }
+            if (notification.badge != null) {
+                var badge_image = new Gtk.Image.from_gicon (notification.badge, LARGE_TOOLBAR) {
+                    pixel_size = 24,
+                    halign = END,
+                    valign = END
+                };
+
+                image_overlay.add_overlay (badge_image);
             }
 
             var title_label = new Gtk.Label (notification.title) {

--- a/src/Bubble.vala
+++ b/src/Bubble.vala
@@ -108,7 +108,7 @@ public class Notifications.Bubble : AbstractBubble {
                 }
             }
 
-            var title_label = new Gtk.Label (notification.summary) {
+            var title_label = new Gtk.Label (notification.title) {
                 ellipsize = Pango.EllipsizeMode.END,
                 max_width_chars = 33,
                 valign = Gtk.Align.END,
@@ -119,7 +119,7 @@ public class Notifications.Bubble : AbstractBubble {
 
             var body_label = new Gtk.Label (notification.body) {
                 ellipsize = Pango.EllipsizeMode.END,
-                lines = 2,
+                lines = "\n" in notification.body ? 1 : 2,
                 max_width_chars = 33,
                 use_markup = true,
                 valign = Gtk.Align.START,
@@ -128,17 +128,6 @@ public class Notifications.Bubble : AbstractBubble {
                 wrap_mode = Pango.WrapMode.WORD_CHAR,
                 xalign = 0
             };
-
-            if ("\n" in notification.body) {
-                string[] lines = notification.body.split ("\n");
-                string stripped_body = lines[0] + "\n";
-                for (int i = 1; i < lines.length; i++) {
-                    stripped_body += lines[i].strip () + "";
-                }
-
-                body_label.label = stripped_body.strip ();
-                body_label.lines = 1;
-            }
 
             column_spacing = 6;
             attach (image_overlay, 0, 0, 1, 2);


### PR DESCRIPTION
this is a push to cleanup the Notification class to make it also usable with other server interfaces, hints are a exclusive concept of the Freedesktop's Notifications interface, and as such, it make more sense to deal with them in the server.

this introduce two behaviour changes:
 - if `app_icon` is a file path or uri, it will be masked when used as primary image of the bubble, but not when used as a badge, this happens because there's no way to differ a GLib.FileIcon icon and a GLib.FileIcon image, given that the focus is the Gtk/Portal interface, i choose to not complicate the logic in the bubble to deal with this conner case.
 - if none of `app_name`, `summary` or the `desktop-entry` hint is specified, we throw a error rather than showing a notification without title.