### PR TITLE
AbstractBubble: set margin in CSS

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -36,6 +36,10 @@ window,
     padding: 6px;
 }
 
+.notification .draw-area {
+    margin: 16px;
+}
+
 .notification:not(.confirmation) .draw-area image {
     -gtk-icon-style: regular;
 }

--- a/src/AbstractBubble.vala
+++ b/src/AbstractBubble.vala
@@ -39,13 +39,12 @@ public class Notifications.AbstractBubble : Gtk.Window {
         };
 
         draw_area = new Gtk.Grid () {
-            hexpand = true,
-            margin = 16
+            hexpand = true
         };
         draw_area.get_style_context ().add_class ("draw-area");
         draw_area.add (content_area);
 
-        var close_button = new Gtk.Button.from_icon_name ("window-close-symbolic", Gtk.IconSize.LARGE_TOOLBAR) {
+        var close_button = new Gtk.Button.from_icon_name ("window-close-symbolic", LARGE_TOOLBAR) {
             halign = Gtk.Align.START,
             valign = Gtk.Align.START
         };

--- a/src/AbstractBubble.vala
+++ b/src/AbstractBubble.vala
@@ -44,7 +44,7 @@ public class Notifications.AbstractBubble : Gtk.Window {
         draw_area.get_style_context ().add_class ("draw-area");
         draw_area.add (content_area);
 
-        var close_button = new Gtk.Button.from_icon_name ("window-close-symbolic", LARGE_TOOLBAR) {
+        var close_button = new Gtk.Button.from_icon_name ("window-close-symbolic", Gtk.IconSize.LARGE_TOOLBAR) {
             halign = Gtk.Align.START,
             valign = Gtk.Align.START
         };


### PR DESCRIPTION
Gtk4 Prep

Set margin in CSS so we don't have to explicitly set every margin property