### PR TITLE
Confirmation: Fix value only showing once it changed

### DIFF
--- a/src/Confirmation.vala
+++ b/src/Confirmation.vala
@@ -55,6 +55,6 @@ public class Notifications.Confirmation : AbstractBubble {
         get_style_context ().add_class ("confirmation");
 
         bind_property ("icon-name", image, "icon-name");
-        bind_property ("progress", progressbar, "fraction");
+        bind_property ("progress", progressbar, "fraction", SYNC_CREATE);
     }
 }


### PR DESCRIPTION
When you e.g. change volume, at the beginning it will show an empty progressbar until you press again so that the value changes.