### PR TITLE
Handle "urgency" and "desktop-entry" hints in server

### DIFF
--- a/src/Notification.vala
+++ b/src/Notification.vala
@@ -1,34 +1,21 @@
 /*
-* Copyright 2020-2023 elementary, Inc. (https://elementary.io)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*
-*/
+ * Copyright 2019-2025 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
-public class Notifications.Notification : GLib.Object {
+public class Notifications.Notification : Object {
     private const string OTHER_APP_ID = "gala-other";
 
-    public GLib.DesktopAppInfo? app_info { get; private set; default = null; }
-    public GLib.NotificationPriority priority { get; private set; default = GLib.NotificationPriority.NORMAL; }
-    public HashTable<string, Variant> hints { get; construct; }
-    public string app_icon { get; construct; }
-    public string app_id { get; private set; default = OTHER_APP_ID; }
     public string app_name { get; construct; }
-    public string body { get; construct set; }
+    public string app_icon { get; construct; }
     public string summary { get; construct set; }
+    public string body { get; construct set; }
+    public DesktopAppInfo? app_info { get; construct; }
+    public HashTable<string, Variant> hints { get; construct; }
+
+    public GLib.NotificationPriority priority { get; set; default = NORMAL; }
+    
+    public string app_id { get; private set; default = OTHER_APP_ID; }
 
     public GLib.Icon? primary_icon { get; set; default = null; }
     public GLib.Icon? badge_icon { get; set; default = null; }
@@ -47,12 +34,13 @@ public class Notifications.Notification : GLib.Object {
         string action_name;
     }
 
-    public Notification (string app_name, string app_icon, string summary, string body, HashTable<string, Variant> hints) {
+    public Notification (string app_name, string app_icon, string summary, string body, DesktopAppInfo? app_info, HashTable<string, Variant> hints) {
         Object (
             app_name: app_name,
             app_icon: app_icon,
             summary: summary,
             body: body,
+            app_info: app_info,
             hints: hints
         );
     }
@@ -67,39 +55,13 @@ public class Notifications.Notification : GLib.Object {
     }
 
     construct {
-        unowned Variant? variant = null;
-
-        // GLib.Notification.set_priority ()
-        // convert between freedesktop urgency levels and GLib.NotificationPriority levels
-        // See: https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html#urgency-levels
-        if ("urgency" in hints && hints["urgency"].is_of_type (VariantType.BYTE)) {
-            switch (hints["urgency"].get_byte ()) {
-                case 0:
-                    priority = LOW;
-                    break;
-                case 1:
-                    priority = NORMAL;
-                    break;
-                case 2:
-                    priority = URGENT;
-                    break;
-                default:
-                    warning ("unknown urgency value: %i, ignoring", hints["urgency"].get_byte ());
-                    break;
-            }
-        }
-
-        if ("desktop-entry" in hints && hints["desktop-entry"].is_of_type (VariantType.STRING)) {
-            app_info = new DesktopAppInfo ("%s.desktop".printf (hints["desktop-entry"].get_string ()));
-
-            if (app_info != null && app_info.get_boolean ("X-GNOME-UsesNotifications")) {
-                var app_info_id = app_info.get_id ();
-                if (app_info_id != null) {
-                    if (app_info_id.has_suffix (".desktop")) {
-                        app_id = app_info_id.substring (0, app_info_id.length - ".desktop".length);
-                    } else {
-                        app_id = app_info_id;
-                    }
+        if (app_info != null && app_info.get_boolean ("X-GNOME-UsesNotifications")) {
+            var app_info_id = app_info.get_id ();
+            if (app_info_id != null) {
+                if (app_info_id.has_suffix (".desktop")) {
+                    app_id = app_info_id.substring (0, app_info_id.length - ".desktop".length);
+                } else {
+                    app_id = app_info_id;
                 }
             }
         }
@@ -116,6 +78,8 @@ public class Notifications.Notification : GLib.Object {
             // Icon name set directly, such as by Notify.Notification
             primary_icon = new ThemedIcon (app_icon);
         }
+
+        unowned Variant? variant = null;
 
         // GLib.Notification.set_icon ()
         if ((variant = hints.lookup ("image-path")) != null || (variant = hints.lookup ("image_path")) != null) {


### PR DESCRIPTION
Almost the same as https://github.com/elementary/notifications/pull/210 but without the image changes

> This is a push to cleanup the Notification class to make it also usable with other server interfaces, hints are a exclusive concept of the Freedesktop's Notifications interface, and as such, it make more sense to deal with them in the server.

