### PR TITLE
CSS: rounder notification, flatter close button

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -10,12 +10,7 @@ window,
     padding: 3px;
     border: none;
     border-radius: 100%;
-    background-image:
-        linear-gradient(
-            to bottom,
-            @BLACK_300,
-            @BLACK_500
-        );
+    background: @BLACK_500;
     box-shadow:
         inset 0 0 0 1px alpha(#fff, 0.02),
         inset 0 1px 0 0 alpha(#fff, 0.07),
@@ -43,8 +38,17 @@ window,
 }
 
 .notification .draw-area {
-    margin: 16px;
     background: alpha(@base_color, 0.8);
+    border-radius: 9px;
+    box-shadow:
+        inset 0 -1px 0 0 alpha(@highlight_color, 0.4),
+        inset 0 1px 0 0 alpha(@highlight_color, 0.6),
+        inset 1px 0 0 0 alpha(@highlight_color, 0.14),
+        inset -1px 0 0 0 alpha(@highlight_color, 0.14),
+        0 0 0 1px @borders,
+        0 1px 3px alpha(black, 0.2),
+        0 3px 9px alpha(black, 0.3);
+    margin: 16px;
 }
 
 .notification.reduce-transparency .draw-area {


### PR DESCRIPTION
* Make notification roundness match the dock
* Less intense shadow (matches box shadow from the dock)
* Make close button flatter/more contrasty

## BEFORE
<img width="390" height="151" alt="Screenshot from 2025-10-06 17 10 42" src="https://github.com/user-attachments/assets/2e27f3dd-e2cf-4b6a-b6c5-7bec3aec780b" />

## AFTER
<img width="390" height="151" alt="Screenshot from 2025-10-06 17 08 22" src="https://github.com/user-attachments/assets/7a3a0022-4ad8-4d82-9c95-a4ead0c9207c" />

