### PR TITLE
CSS: modernize for Gtk 4.20+

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ a Gtk notification server for Pantheon
 You'll need the following dependencies:
 * libcanberra
 * libgranite-7-dev (>=7.7.0)
-* libgtk-4-dev
+* libgtk-4-dev (>=4.20)
 * libadwaita-1-dev (>=1.0.0)
 * meson
 * valac

--- a/data/application.css
+++ b/data/application.css
@@ -12,7 +12,7 @@ window,
     border-radius: 100%;
     background: @BLACK_500;
     box-shadow:
-        inset 0 0 0 1px color-mix(in srgb, white 20%, transparent),
+        inset 0 0 0 1px color-mix(in srgb, white 2%, transparent),
         inset 0 1px 0 0 color-mix(in srgb, white 7%, transparent),
         inset 0 -1px 0 0 color-mix(in srgb, white 1%, transparent),
         0 0 0 1px color-mix(in srgb, black 7%, transparent),

--- a/data/application.css
+++ b/data/application.css
@@ -12,19 +12,19 @@ window,
     border-radius: 100%;
     background: @BLACK_500;
     box-shadow:
-        inset 0 0 0 1px alpha(#fff, 0.02),
-        inset 0 1px 0 0 alpha(#fff, 0.07),
-        inset 0 -1px 0 0 alpha(#fff, 0.01),
-        0 0 0 1px alpha(#000, 0.7),
-        0 1px 2px alpha(#000, 0.16),
-        0 2px 3px alpha(#000, 0.23);
+        inset 0 0 0 1px color-mix(in srgb, white 20%, transparent),
+        inset 0 1px 0 0 color-mix(in srgb, white 7%, transparent),
+        inset 0 -1px 0 0 color-mix(in srgb, white 1%, transparent),
+        0 0 0 1px color-mix(in srgb, black 7%, transparent),
+        0 1px 2px color-mix(in srgb, black 16%, transparent),
+        0 2px 3px color-mix(in srgb, black 23%, transparent);
     margin: 3px;
     -gtk-icon-size: 24px;
 }
 
 .close image {
     color: #fff;
-    -gtk-icon-shadow: 0 1px 1px alpha(#000, 0.6);
+    -gtk-icon-shadow: 0 1px 1px color-mix(in srgb, black 6%, transparent);
 }
 
 .notification stack > box,
@@ -41,13 +41,13 @@ window,
     background: alpha(@base_color, 0.8);
     border-radius: 9px;
     box-shadow:
-        inset 0 -1px 0 0 alpha(@highlight_color, 0.4),
-        inset 0 1px 0 0 alpha(@highlight_color, 0.6),
-        inset 1px 0 0 0 alpha(@highlight_color, 0.14),
-        inset -1px 0 0 0 alpha(@highlight_color, 0.14),
+        inset 0 -1px 0 0 color-mix(in srgb, @highlight_color 40%, transparent),
+        inset 0 1px 0 0 color-mix(in srgb, @highlight_color 60%, transparent),
+        inset 1px 0 0 0 color-mix(in srgb, @highlight_color 14%, transparent),
+        inset -1px 0 0 0 color-mix(in srgb, @highlight_color 14%, transparent),
         0 0 0 1px @borders,
-        0 1px 3px alpha(black, 0.2),
-        0 3px 9px alpha(black, 0.3);
+        0 1px 3px color-mix(in srgb, black 20%, transparent),
+        0 3px 9px color-mix(in srgb, black 30%, transparent);
     margin: 16px;
 }
 

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ executable(
         dependency ('gobject-2.0'),
         dependency ('gio-2.0'),
         dependency ('granite-7', version: '>=7.7.0'),
-        dependency ('gtk4'),
+        dependency ('gtk4', version: '>=4.20'),
         dependency('gtk4-wayland'),
         dependency('gtk4-x11'),
         dependency ('gtk4-x11'),


### PR DESCRIPTION
Use color-mix. After porting to Granite 9 we can use new css style variables