### PR TITLE
Styles: use OSD for close button

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -6,7 +6,7 @@ window,
     padding: 0;
 }
 
-.close {
+button.osd {
    border-radius: 100%;
    background: @BLACK_500;
    box-shadow:

--- a/data/application.css
+++ b/data/application.css
@@ -7,24 +7,18 @@ window,
 }
 
 .close {
-    padding: 3px;
-    border: none;
-    border-radius: 100%;
-    background: @BLACK_500;
-    box-shadow:
-        inset 0 0 0 1px alpha(#fff, 0.02),
-        inset 0 1px 0 0 alpha(#fff, 0.07),
-        inset 0 -1px 0 0 alpha(#fff, 0.01),
-        0 0 0 1px alpha(#000, 0.7),
-        0 1px 2px alpha(#000, 0.16),
-        0 2px 3px alpha(#000, 0.23);
-    margin: 3px;
-    -gtk-icon-size: 24px;
-}
-
-.close image {
-    color: #fff;
-    -gtk-icon-shadow: 0 1px 1px alpha(#000, 0.6);
+   border-radius: 100%;
+   background: @BLACK_500;
+   box-shadow:
+       inset 0 0 0 1px alpha(#fff, 0.02),
+       inset 0 1px 0 0 alpha(#fff, 0.07),
+       inset 0 -1px 0 0 alpha(#fff, 0.01),
+       0 0 0 1px alpha(#000, 0.7),
+       0 1px 2px alpha(#000, 0.16),
+       0 2px 3px alpha(#000, 0.23);
+   margin: 3px;
+   -gtk-icon-shadow: 0 1px 1px alpha(#000, 0.6);
+   -gtk-icon-size: 24px;
 }
 
 .notification stack > box,

--- a/src/AbstractBubble.vala
+++ b/src/AbstractBubble.vala
@@ -73,7 +73,6 @@ public class Notifications.AbstractBubble : Gtk.Window {
             valign = Gtk.Align.START
         };
         close_button.add_css_class (Granite.STYLE_CLASS_OSD);
-        close_button.add_css_class ("close");
 
         close_revealer = new Gtk.Revealer () {
             reveal_child = false,

--- a/src/AbstractBubble.vala
+++ b/src/AbstractBubble.vala
@@ -73,7 +73,6 @@ public class Notifications.AbstractBubble : Gtk.Window {
             valign = Gtk.Align.START
         };
         close_button.add_css_class (Granite.STYLE_CLASS_OSD);
-        close_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
         close_button.add_css_class ("close");
 
         close_revealer = new Gtk.Revealer () {

--- a/src/AbstractBubble.vala
+++ b/src/AbstractBubble.vala
@@ -72,6 +72,8 @@ public class Notifications.AbstractBubble : Gtk.Window {
             halign = Gtk.Align.START,
             valign = Gtk.Align.START
         };
+        close_button.add_css_class (Granite.STYLE_CLASS_OSD);
+        close_button.add_css_class (Granite.STYLE_CLASS_LARGE_ICONS);
         close_button.add_css_class ("close");
 
         close_revealer = new Gtk.Revealer () {


### PR DESCRIPTION
Fixes #274 

Ideally in Granite9 we have default styles for `button.osd` but until that time we can clean up a few things here